### PR TITLE
Added SSL to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 Shop/src
 Shop/database
+Shop/ssl/prestashop.crt
+Shop/ssl/prestashop.key
 Shop/db_dump
 scraper/venv
 .venv

--- a/Shop/Dockerfile
+++ b/Shop/Dockerfile
@@ -1,0 +1,8 @@
+FROM prestashop/prestashop:1.7.8-apache
+
+COPY ./ssl/prestashop.crt /etc/ssl/certs/prestashop.crt
+COPY ./ssl/prestashop.crt /usr/local/share/ca-certificates/prestashop.crt
+COPY ./ssl/prestashop.key /etc/ssl/private/prestashop.key
+COPY ./ssl/prestashop-ssl.conf /etc/apache2/sites-available/prestashop-ssl.conf
+
+RUN update-ca-certificates && a2enmod ssl && a2ensite prestashop-ssl

--- a/Shop/docker-compose.yml
+++ b/Shop/docker-compose.yml
@@ -18,9 +18,12 @@ services:
   prestashop:
     container_name: prestashop
     platform: linux/x86_64
-    image: prestashop/prestashop:1.7.8.10-apache
+    build:
+      context: .
+      dockerfile: Dockerfile
     restart: unless-stopped
     ports:
+      - 443:443
       - 8080:80
     volumes:
       - ./src:/var/www/html

--- a/Shop/ssl/command.txt
+++ b/Shop/ssl/command.txt
@@ -1,0 +1,1 @@
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout prestashop.key -out prestashop.crt -subj "/C=PL/ST=Pomorskie/L=Gdansk/O=Kule Hermiony/OU=Kule Hermiony/CN=localhost"

--- a/Shop/ssl/prestashop-ssl.conf
+++ b/Shop/ssl/prestashop-ssl.conf
@@ -1,0 +1,11 @@
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/prestashop.crt
+    SSLCertificateKeyFile /etc/ssl/private/prestashop.key
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ServerName localhost
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>


### PR DESCRIPTION
Closes #5 

Instructions:
1. Usuń wszystkie dane, aby rozpocząć od nowa z naszym sklepem (komenda: rm -rf src/database/db_dump).
2. Przejdź do katalogu Shop (cd Shop/).
3. Uruchom Docker Compose (docker-compose up).
4. Przejdź przez standardową instalację, ale NIE ZAZNACZAJ opcji dotyczącej SSL.
5. Zmień nazwę folderu "admin" na "adminpanel" i usuń folder "install".
6. Wejdź w panel admina > Preferencje > Ruch.
7. Na pierwszej zakładce ustaw pola "Ustaw URL sklepu" następująco:
	Domena sklepu: localhost:8080
	Domena SSL: localhost
	URI bazowy: /
8. Zapisz te ustawienia i przejdź do Preferencje > Ogólne.
9. Kliknij link, aby włączyć SSL ("Włącz SSL") i zapisz.
10. Poniżej tego, przy opcji "Włącz protokół SSL na wszystkich stronach", zaznacz "Tak" i zapisz.